### PR TITLE
Added files directory and will copy local files to server on deploy

### DIFF
--- a/lib/sunzi/cli.rb
+++ b/lib/sunzi/cli.rb
@@ -45,7 +45,7 @@ module Sunzi
         template "templates/create/roles/app.sh",       "#{project}/roles/app.sh"
         template "templates/create/roles/db.sh",        "#{project}/roles/db.sh"
         template "templates/create/roles/web.sh",       "#{project}/roles/web.sh"
-        empty_directory                                 "#{project}/files"
+        empty_directory                                 "#{project}/templates"
       end
 
       def do_deploy(target, role)
@@ -110,8 +110,10 @@ module Sunzi
         # Copy local files
         Dir['recipes/*'].each         {|file| copy_file File.expand_path(file), "compiled/recipes/#{File.basename(file)}" }
         Dir['roles/*'].each           {|file| copy_file File.expand_path(file), "compiled/roles/#{File.basename(file)}" }
-        Dir['files/*'].each           {|file| copy_file File.expand_path(file), "compiled/files/#{File.basename(file)}" }
         (@config['files'] || []).each {|file| copy_file File.expand_path(file), "compiled/files/#{File.basename(file)}" }
+
+        # Copy local templates
+        Dir['templates/*'].each       {|file| template File.expand_path(file), "compiled/files/#{File.basename(file)}", @config['attributes'] }
 
         # Build install.sh
         if role


### PR DESCRIPTION
Even though sunzi can already pull in files that are specified in sunzi.yml, I often have other static files that are specific to provisioning a specific box.  Those files make sense to only live in my project repo.  Think of nginx config and vhost files.

Rather than giving these an absolute path to my sunzi-based project, I'd prefer to just add them to the project in a 'files' directory.  I just need sunzi to then copy that directory over into the compiled directory as part of a deployment.

Let me know if you think this makes sense. 
