### PR TITLE
Add a flag to call install.sh with sudo

### DIFF
--- a/lib/sunzi/cli.rb
+++ b/lib/sunzi/cli.rb
@@ -9,9 +9,10 @@ module Sunzi
       do_create(project)
     end
 
-    desc "deploy [user@host:port] [role] [using_sudo]", "Deploy sunzi project"
-    def deploy(target, role = nil, using_sudo = false)
-      do_deploy(target, role, using_sudo)
+    desc "deploy [user@host:port] [role] [--sudo]", "Deploy sunzi project"
+    method_options :sudo => false
+    def deploy(target, role = nil)
+      do_deploy(target, role, options.sudo?)
     end
 
     desc "compile", "Compile sunzi project"
@@ -47,8 +48,8 @@ module Sunzi
         template "templates/create/roles/web.sh",       "#{project}/roles/web.sh"
       end
 
-      def do_deploy(target, role, using_sudo)
-        sudo = 'sudo ' if using_sudo == 'true'
+      def do_deploy(target, role, force_sudo)
+        sudo = 'sudo ' if force_sudo
         user, host, port = parse_target(target)
         endpoint = "#{user}@#{host}"
 


### PR DESCRIPTION
When deploying on EC2, I'm stuck with the ubuntu user that is created by default.  I often need to use the passwordless sudo in order to do something as root (i.e. upgrade, install, etc.).  However, I don't want that to be sprinkled all through my recipes because it's not needed on other VM hosts (i.e. Linode).

To support that, I added a --sudo flag to the deploy call so that sudo can be requested as a run-time option.  I've defaulted it to false to support backwards compatibility.  A deploy call would now look like this:

```
 sunzi deploy ubuntu@0.0.0.0 app --sudo
```

A call that omitted the --sudo would be run as normal.
