### PR TITLE
fix sunzi.install in foreach packages

### DIFF
--- a/lib/templates/create/recipes/sunzi.sh
+++ b/lib/templates/create/recipes/sunzi.sh
@@ -40,11 +40,9 @@ function sunzi.install() {
   do
     if sunzi.installed "$name"; then
       echo "$name already installed"
-      return 1
     else
       echo "No packages found matching $name. Installing..."
       sunzi.mute "$sunzi_pkg -y install $name"
-      return 0
     fi
   done
 }


### PR DESCRIPTION
For example, in the following cases:

```
sunzi.install "build-essential libreadline6-dev zlib1g-dev libssl-dev libxml2-dev libxslt1-dev"
```
