### PR TITLE
Load ssh config if possible.

### DIFF
--- a/lib/sunzi/cli.rb
+++ b/lib/sunzi/cli.rb
@@ -1,5 +1,6 @@
 require 'open3'
 require 'ostruct'
+require 'net/ssh'
 
 module Sunzi
   class Cli < Thor
@@ -136,7 +137,11 @@ module Sunzi
 
       def parse_target(target)
         target.match(/(.*@)?(.*?)(:.*)?$/)
-        [ ($1 && $1.delete('@') || 'root'), $2, ($3 && $3.delete(':') || '22') ]
+        # Load from ssh's config, if it exists.
+        config = Net::SSH::Config.for($2)
+        [ ($1 && $1.delete('@') || config[:user] || 'root'), 
+          config[:host_name] || $2, 
+          ($3 && $3.delete(':') || config[:port] && config[:port].to_s || '22') ]
       end
     end
   end

--- a/sunzi.gemspec
+++ b/sunzi.gemspec
@@ -17,5 +17,6 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'thor'
   spec.add_runtime_dependency 'rainbow'
+  spec.add_runtime_dependency 'net-ssh'
   spec.add_development_dependency 'rake'
 end

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -1,5 +1,7 @@
 require 'sunzi'
+require 'net/ssh'
 require 'test/unit'
+require 'minitest/mock'
 
 class TestCli < Test::Unit::TestCase
   def setup
@@ -7,11 +9,36 @@ class TestCli < Test::Unit::TestCase
   end
 
   def test_parse_target
-    assert_equal ['user', 'example.com', '2222'], @cli.parse_target('user@example.com:2222')
-    assert_equal ['root', 'example.com', '2222'], @cli.parse_target('example.com:2222')
-    assert_equal ['user', 'example.com', '22'],   @cli.parse_target('user@example.com')
-    assert_equal ['root', 'example.com', '22'],   @cli.parse_target('example.com')
-    assert_equal ['root', '192.168.0.1', '22'],   @cli.parse_target('192.168.0.1')
+    Net::SSH::Config.stub(:for, {}) do
+      assert_equal ['user', 'example.com', '2222'], @cli.parse_target('user@example.com:2222')
+      assert_equal ['root', 'example.com', '2222'], @cli.parse_target('example.com:2222')
+      assert_equal ['user', 'example.com', '22'],   @cli.parse_target('user@example.com')
+      assert_equal ['root', 'example.com', '22'],   @cli.parse_target('example.com')
+      assert_equal ['root', '192.168.0.1', '22'],   @cli.parse_target('192.168.0.1')
+    end
+  end
+
+  def test_parse_target_with_ssh_config
+    dummy_config = lambda do |host|
+      if host == 'example.com'
+        {
+          :host_name => "buzz.example.com",
+          :user => "foobar",
+          :port => 2222,
+          :keys => ["my_id_rsa"]
+        }
+      else
+        {}
+      end
+    end
+
+    Net::SSH::Config.stub(:for, dummy_config) do
+      assert_equal ['foobar', 'buzz.example.com', '2222'], @cli.parse_target('example.com')
+      assert_equal ['foobar', 'buzz.example.com', '8080'], @cli.parse_target('example.com:8080')
+      assert_equal ['piyo', 'buzz.example.com', '2222'], @cli.parse_target('piyo@example.com')
+      assert_equal ['piyo', 'buzz.example.com', '8080'], @cli.parse_target('piyo@example.com:8080')
+      assert_equal ['root', '192.168.0.1', '22'], @cli.parse_target('192.168.0.1')
+    end
   end
 
   def test_create


### PR DESCRIPTION
Fix a problem as follows: 
## :smile: :smile: :smile:   Expected: :smile: :smile: :smile:

```
$ tail -5 ~/.ssh/config
Host example
    HostName buzz.example.com
    User foobar
    Port 2222

$ sunzi deploy example --sudo
(((snip snip snip)))  
$ # DONE!!
```

This is nice. :+1: 
## :shit: :shit: :shit: Actual: :shit: :shit: :shit:

```
$ # It's the same as above...  

$ sunzi deploy example --sudo
(((snip snip snip)))  
ssh: Could not resolve hostname example: Name or service not known
```

> **ssh: Could not resolve hostname example** :weary:

I can not deploy with ssh config.  :broken_heart:
