### PR TITLE
Sunzi run

### DIFF
--- a/lib/templates/create/recipes/sunzi.sh
+++ b/lib/templates/create/recipes/sunzi.sh
@@ -55,7 +55,8 @@ function sunzi.install() {
 #     # do stuff...
 #   }
 #
-#   # will run only the function once
+#   # will only run the function once
+#   # regardless of how many times sunzi deploy is executed
 #   sunzi.run "setup_nodejs"
 #
 #   # force to run every time


### PR DESCRIPTION
Added a `sunzi.run` function as a simple idempotent solution for running bash functions. Simply define a specific provisioning operation in a bash function & then call `sunzi.run` like so.

``` sh
# install.sh

function pf.update_sources() {
  apt-get install -y lsb-release
  echo deb http://archive.ubuntu.com/ubuntu $(lsb_release -cs) main universe > /etc/apt/sources.list.d/universe.list
  apt-get -qq update
  apt-get -qq -y dist-upgrade
}

sunzi.run "pf.update_sources"
```

Invoking a fuction with `sunzi.run` only executes the function once regardless of how many times `sunzi deploy` is run. The implementation simply touches a file at `/etc/sunzi_run/FUNCTION_NAME` & then checks for the existence of this file to determine whether or not to run the function.

This simple idempotency solution has proved invaluable for me, making Sunzi a viable alternative to heavier tools like Chef & Puppet. 
