### PR TITLE
Aliased deploy as provision.

### DIFF
--- a/lib/sunzi/cli.rb
+++ b/lib/sunzi/cli.rb
@@ -16,6 +16,7 @@ module Sunzi
     def deploy(first, *args)
       do_deploy(first, *args)
     end
+    alias_method :provision, :deploy
 
     desc 'compile', 'Compile sunzi project'
     def compile(role = nil)
@@ -152,8 +153,8 @@ module Sunzi
         target.match(/(.*@)?(.*?)(:.*)?$/)
         # Load ssh config if it exists
         config = Net::SSH::Config.for($2)
-        [ ($1 && $1.delete('@') || config[:user] || 'root'), 
-          config[:host_name] || $2, 
+        [ ($1 && $1.delete('@') || config[:user] || 'root'),
+          config[:host_name] || $2,
           ($3 && $3.delete(':') || config[:port] && config[:port].to_s || '22') ]
       end
     end


### PR DESCRIPTION
I think of Sunzi as a provisioning tool rather than a deployment tool. In fact I use different solutions for application deployment. Distinct semantics that differentiate between deployment & provisioning helps me isolate workflow concerns.
