### PR TITLE
added explict rainbow string category methods

### DIFF
--- a/lib/sunzi.rb
+++ b/lib/sunzi.rb
@@ -1,5 +1,6 @@
 require 'thor'
 require 'rainbow'
+require 'rainbow/ext/string'
 require 'yaml'
 
 module Sunzi


### PR DESCRIPTION
Looks like the rainbow library was updated and moved the String category methods into their own class. This was causing sunzi deploy and others to get errors like this:

`block (2 levels) in do_deploy': undefined method`color' for #String:0x007fb84c253c60 (NoMethodError)

This pull request should fix that. :)
