### PR TITLE
Support multiple roles applications

### DIFF
--- a/lib/sunzi/cli.rb
+++ b/lib/sunzi/cli.rb
@@ -58,7 +58,7 @@ module Sunzi
         if ['linode', 'digital_ocean'].include?(first)
           @instance_attributes = YAML.load(File.read("#{first}/instances/#{args[0]}.yml"))
           target = @instance_attributes[:fqdn]
-          roles = args[1, -1]
+          roles = args.drop(1)
         else
           target = first
           roles = args


### PR DESCRIPTION
Allow passing more than one role to be applied.

```
$ sunzi create
      create  sunzi/.gitignore
      create  sunzi/sunzi.yml
      create  sunzi/install.sh
      create  sunzi/recipes/sunzi.sh
      create  sunzi/roles/db.sh
      create  sunzi/roles/web.sh
      create  sunzi/files/.gitkeep
$ cd sunzi
$ sunzi compile db web
      create  compiled/attributes/environment
      create  compiled/attributes/ruby_version
      create  compiled/recipes/rvm.sh
      create  compiled/recipes/sunzi.sh
      create  compiled/roles/db.sh
      create  compiled/roles/web.sh
      create  compiled/_install.sh
      create  compiled/install.sh
```
