### PR TITLE
Update and simplify Vagrant instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,19 +171,11 @@ If you're using Sunzi with [Vagrant](http://vagrantup.com/), make sure that you 
 An easy way is to edit `Vagrantfile`:
 
 ```ruby
-Vagrant::Config.run do |config|
-  config.vm.provision :shell do |shell|
-    shell.path = "chpasswd.sh"
+Vagrant.configure("2") do |config|
+  config.vm.provision "shell",
+    inline: "sudo echo 'root:vagrant' | /usr/sbin/chpasswd"
   end
 end
-```
-
-with `chpasswd.sh`:
-
-```bash
-#!/bin/bash
-
-sudo echo 'root:vagrant' | /usr/sbin/chpasswd
 ```
 
 and now run `vagrant up`, it will change the root password to `vagrant`.


### PR DESCRIPTION
Since the chpasswd script was just a one-liner, why not include it w/ the `inline:` option when provisioning the VM? This makes the code a little bit simpler. It also updates the syntax for Vagrant to be inline with their docs.
