### PR TITLE
Use new user content domain instead of older one.

### DIFF
--- a/lib/templates/create/sunzi.yml
+++ b/lib/templates/create/sunzi.yml
@@ -6,10 +6,10 @@ attributes:
 
 # Remote recipes here will be downloaded to compiled/recipes.
 recipes:
-  rvm: https://raw.github.com/kenn/sunzi-recipes/master/ruby/rvm.sh
-  # dotdeb: https://raw.github.com/kenn/sunzi-recipes/master/debian/dotdeb-wheezy.sh
-  # backports: https://raw.github.com/kenn/sunzi-recipes/master/debian/backports-wheezy.sh
-  # mongodb-10gen: https://raw.github.com/kenn/sunzi-recipes/master/debian/mongodb-10gen.sh
+  rvm: https://raw.githubusercontent.com/kenn/sunzi-recipes/master/ruby/rvm.sh
+  # dotdeb: https://raw.githubusercontent.com/kenn/sunzi-recipes/master/debian/dotdeb-wheezy.sh
+  # backports: https://raw.githubusercontent.com/kenn/sunzi-recipes/master/debian/backports-wheezy.sh
+  # mongodb-10gen: https://raw.githubusercontent.com/kenn/sunzi-recipes/master/debian/mongodb-10gen.sh
 
 # Files specified here will be copied to compiled/files.
 # files:


### PR DESCRIPTION
GitHub changed raw contents' url.
They provides url redirection for now, but I think it's better to change url in `sunzi.yml`.

https://developer.github.com/changes/2014-04-25-user-content-security/
