### PR TITLE
Delete unexpected `end`

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,6 @@ An easy way is to edit `Vagrantfile`:
 Vagrant.configure("2") do |config|
   config.vm.provision "shell",
     inline: "sudo echo 'root:vagrant' | /usr/sbin/chpasswd"
-  end
 end
 ```
 


### PR DESCRIPTION
Hi @kenn, I found a small syntax error in the `Vagrantfile ` example. Inner `end` shouldn't be there.
ref: [Inline Scripts](https://www.vagrantup.com/docs/provisioning/shell#inline-scripts)

```
$ cat Vagrantfile
# -*- mode: ruby -*-
# vi: set ft=ruby :

Vagrant.configure("2") do |config|
  config.vm.box = "ubuntu/focal64"
  config.vm.provision "shell",
    inline: "sudo echo 'root:vagrant' | /usr/sbin/chpasswd"
  end
end

$ vagrant up
Vagrant failed to initialize at a very early stage:

There is a syntax error in the following Vagrantfile. The syntax error
message is reproduced below for convenience:

/Users/kyanny/workspaces/tmp-sunzi/Vagrantfile:9: syntax error, unexpected `end', expecting end-of-input

```