### PR TITLE
Relax dependent `thor` version to fix CI

### DIFF
--- a/sunzi.gemspec
+++ b/sunzi.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'thor', '~> 0.20'
+  spec.add_dependency 'thor'
   spec.add_dependency 'rainbow', '~> 3.0'
   spec.add_dependency 'net-ssh', '< 5' # 4.x only supports ruby-2.0
   spec.add_dependency 'hashugar'


### PR DESCRIPTION
`sunzi`'s CI failed with `ruby-head (3.2.0dev)`.
https://github.com/kenn/sunzi/pull/45/checks?check_run_id=5319265537

That's because `sunzi` depends on older `thor` (v0.20.x), `thor` at that version uses `open-uri` internally, but `open-uri` was removed since Ruby 3.x release.
https://github.com/ruby/ruby/blob/v3_0_0/NEWS.md#compatibility-issues

`thor` v1.x uses `URI.open` so that it is compatible with Ruby 3.x.
https://github.com/rails/thor/pull/677

This pull request removes dependent `thor` version from the gemspec file, so that `sunzi` will use newer `thor` and it works fine with Ruby 3.x.

-----

Before this patch:

```
ruby-2.7.2: ruby 2.7.2p137 (2020-10-01 revision 5445e04352) [x86_64-linux] 
Run options: --seed 7920

# Running:

....

Finished in 0.241189s, 16.5845 runs/s, 132.6760 assertions/s.

4 runs, 32 assertions, 0 failures, 0 errors, 0 skips


ruby-3.0.0: ruby 3.0.0p0 (2020-12-25 revision 95aff21468) [x86_64-linux] 
Run options: --seed 40040

# Running:

...E

Finished in 0.031828s, 125.6742 runs/s, 628.3711 assertions/s.

  1) Error:
TestCommand#test_compile:
Errno::ENOENT: No such file or directory @ rb_sysopen - https://raw.github.com/kenn/sunzi-recipes/master/ruby/rvm.sh
    /usr/local/rvm/gems/ruby-3.0.0/gems/thor-0.20.3/lib/thor/actions/file_manipulation.rb:89:in `initialize'
    /usr/local/rvm/gems/ruby-3.0.0/gems/thor-0.20.3/lib/thor/actions/file_manipulation.rb:89:in `open'
    /usr/local/rvm/gems/ruby-3.0.0/gems/thor-0.20.3/lib/thor/actions/file_manipulation.rb:89:in `get'
    /usr/local/rvm/rubies/ruby-3.0.0/lib/ruby/3.0.0/forwardable.rb:238:in `get'
    /root/sunzi/lib/sunzi/command.rb:69:in `block in compile'
    /usr/local/rvm/gems/ruby-3.0.0/gems/hashugar-1.0.1/lib/hashugar.rb:36:in `each'
    /usr/local/rvm/gems/ruby-3.0.0/gems/hashugar-1.0.1/lib/hashugar.rb:36:in `each'
    /root/sunzi/lib/sunzi/command.rb:66:in `compile'
    /root/sunzi/test/command_test.rb:34:in `block in test_compile'

4 runs, 20 assertions, 0 failures, 1 errors, 0 skips

```

After this patch (`bundle install && bundle update`):

```
ruby-2.7.2: ruby 2.7.2p137 (2020-10-01 revision 5445e04352) [x86_64-linux] 
Run options: --seed 21643

# Running:

....

Finished in 0.260584s, 15.3501 runs/s, 122.8011 assertions/s.

4 runs, 32 assertions, 0 failures, 0 errors, 0 skips


ruby-3.0.0: ruby 3.0.0p0 (2020-12-25 revision 95aff21468) [x86_64-linux] 
Run options: --seed 26678

# Running:

....

Finished in 0.080398s, 49.7524 runs/s, 398.0196 assertions/s.

4 runs, 32 assertions, 0 failures, 0 errors, 0 skips

```